### PR TITLE
Fix range input for hardware temperature and humidity offset for ZSE11 and ZSE44

### DIFF
--- a/Drivers/zooz/zooz-zse11-q-sensor.groovy
+++ b/Drivers/zooz/zooz-zse11-q-sensor.groovy
@@ -87,7 +87,7 @@ metadata {
 						required: false
 				}
 				else if (param.range) {
-					input "configParam${param.num}", "number",
+					input "configParam${param.num}", param.dataType ?: "number",
 						title: fmtTitle("${param.title}"),
 						description: fmtDesc("• Parameter #${param.num}, Range: ${(param.range).toString()}, DEFAULT: ${param.defaultVal}" + (param?.description ? "<br>• ${param?.description}" : '')),
 						defaultValue: param.defaultVal,
@@ -250,13 +250,15 @@ void debugShowVars() {
 	tempOffsetHw: [ num:201,
 		title: "Temperature Offset (Hardware)",
 		size: 1, defaultVal: 0,
-		range: "-10.0..10.0",
+		range: "-10..10",
+		dataType: "decimal",
 		firmVer: 2.0
 	],
 	humidOffsetHw: [ num:202,
 		title: "Humidity Offset (Hardware)",
 		size: 1, defaultVal: 0,
-		range: "-10.0..10.0",
+		range: "-10..10",
+		dataType: "decimal",
 		firmVer: 2.0
 	],
 	lightOffsetHw: [ num:203,

--- a/Drivers/zooz/zooz-zse44-temp-humidity.groovy
+++ b/Drivers/zooz/zooz-zse44-temp-humidity.groovy
@@ -120,7 +120,7 @@ metadata {
 						required: false
 				}
 				else if (param.range) {
-					input "configParam${param.num}", "number",
+					input "configParam${param.num}", param.dataType ?: "number",
 						title: fmtTitle("${param.title}"),
 						description: fmtDesc("• Parameter #${param.num}, Range: ${(param.range).toString()}, DEFAULT: ${param.defaultVal}" + (param?.description ? "<br>• ${param?.description}" : '')),
 						defaultValue: param.defaultVal,
@@ -189,12 +189,14 @@ void debugShowVars() {
 	tempOffsetHw: [ num:14,
 		title: "Temperature Offset (Hardware)",
 		size: 1, defaultVal: 0,
-		range: "-10.0..10.0"
+		range: "-10..10",
+		dataType: "decimal"
 	],
 	humidOffsetHw: [ num:15,
 		title: "Humidity Offset (Hardware)",
 		size: 1, defaultVal: 0,
-		range: "-10.0..10.0"
+		range: "-10..10",
+		dataType: "decimal"
 	],
 	tempInterval: [ num:16,
 		title: "Temperature Reporting Interval (mins)",


### PR DESCRIPTION
This PR address #41.

The fix involves adding a new, optional value to the `paramsMap` array called `dataType`. It supports specifying an alternate data type, such as `"decimal"` so that the code in the `configParams.each` closure within `metadata.preferences`  uses the `dataType` member in the `input` function if provided.